### PR TITLE
chore: increase minimum font sizes to prevent iOS zoom effect

### DIFF
--- a/volumes/lembrador-contas/src/public/stylesheets/starter-template.css
+++ b/volumes/lembrador-contas/src/public/stylesheets/starter-template.css
@@ -140,7 +140,7 @@ select.form-control {
 .btn {
   border-radius: var(--radius-sm);
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 1rem;
   padding: 0.5rem 1rem;
   transition: all var(--transition);
 }
@@ -196,14 +196,14 @@ select.form-control {
   border-color: var(--border);
   padding: 0.75rem 0.75rem;
   vertical-align: middle;
-  font-size: 0.9rem;
+  font-size: 1rem;
 }
 .table thead th {
   background-color: var(--bg-elevated);
   color: var(--text-secondary);
   border-color: var(--border);
   font-weight: 600;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -227,7 +227,7 @@ select.form-control {
   border-radius: var(--radius-sm);
   padding: 0.55rem 0.875rem;
   font-family: var(--font);
-  font-size: 0.9rem;
+  font-size: 1rem;
   line-height: 1.5;
   height: auto;
   transition: all var(--transition);
@@ -250,7 +250,7 @@ select.form-control {
 
 label {
   color: var(--text-secondary);
-  font-size: 0.8rem;
+  font-size: 1rem;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -275,7 +275,7 @@ label {
   color: var(--text-primary);
   border-radius: var(--radius-sm);
   padding: 0.5rem 0.875rem;
-  font-size: 0.875rem;
+  font-size: 1rem;
   transition: all var(--transition);
 }
 .dropdown-item:hover,
@@ -326,7 +326,7 @@ label {
   font-size: 1.1rem;
   font-weight: 600;
 }
-.card p { margin: 0.4rem 0; font-size: 0.9rem; color: var(--text-secondary); }
+.card p { margin: 0.4rem 0; font-size: 1rem; color: var(--text-secondary); }
 
 /* ===== Bootstrap 4 Alert ===== */
 .alert {
@@ -364,7 +364,7 @@ label {
 }
 
 .filter-group label {
-  font-size: 0.7rem;
+  font-size: 0.875rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   margin-bottom: 0.35rem;
@@ -392,7 +392,7 @@ label {
 .navbar .nav-link {
   color: var(--text-secondary) !important;
   font-weight: 500;
-  font-size: 0.875rem;
+  font-size: 1rem;
   padding: 0.5rem 0.75rem !important;
   border-radius: var(--radius-sm);
   transition: all var(--transition);
@@ -427,7 +427,7 @@ html.light-theme .navbar-toggler-icon {
 
 #navbar-user-email {
   color: var(--text-secondary) !important;
-  font-size: 0.8rem;
+  font-size: 1rem;
 }
 
 /* ===== Dashboard Layout ===== */
@@ -555,7 +555,7 @@ html.light-theme .navbar-toggler-icon {
 }
 
 .payment-badges .badge {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   padding: 0.35em 0.75em;
   border-radius: 999px;
   font-weight: 500;
@@ -652,10 +652,10 @@ html.light-theme .navbar-toggler-icon {
   .month-header { font-size: 0.9em; }
   .bill-table td,
   .bill-table th {
-    font-size: 0.85rem;
+    font-size: 1rem;
     padding: 0.5rem 0.4rem;
   }
   .navbar-brand {
-    font-size: 0.95rem;
+    font-size: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
Increase minimum font sizes across the project to prevent Safari's automatic zoom behavior on iOS devices when focusing on input fields.

## Changes
- Form controls: 0.9rem → 1rem (16px)
- Labels: 0.8rem → 1rem (16px)
- Buttons: 0.875rem → 1rem (16px)
- Table cells: 0.9rem → 1rem (16px)
- Dropdown items: 0.875rem → 1rem (16px)
- Navbar links: 0.875rem → 1rem (16px)
- Card paragraphs: 0.9rem → 1rem (16px)
- Navbar user email: 0.8rem → 1rem (16px)
- Secondary elements: 0.7-0.75rem → 0.875rem (14px)

## Why
iOS Safari automatically zooms in when focusing on input fields with font sizes smaller than 16px. This is a built-in behavior to ensure readability. By setting all interactive elements to at least 16px, we prevent this unwanted zoom effect and provide better mobile UX.